### PR TITLE
Add pages for Reflections

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,18 +2,18 @@
 
 <head>
     <title>CSC428 - Home</title>
+    <link href="style.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 
 <body>
     <!-- Course overview -->
     <h1>CSC428 - Home</h1>
     <h2>Overview</h2>
-    <p>
-
-
-    </p>
-
-    <h2>Propsoed Structure for each class</h2>
+    <hr/>
+    <h2>Proposed Structure for each class</h2>
     <p>
         6:00-6:10 - Introduction to the class and the course<br>
         6:10-6:35 - Individually watching loom videos 10-15 minutes, 5-10 min share thoughts on discord, Joseph talks<br>
@@ -21,10 +21,17 @@
         7:10-7:20 - Individual work in breakout rooms<br>
         7:20-7:35 - Ask me anything joseph<br>
         7:35-8:00 - Report back, wrap up<br>
-
     </p>
 
+    <h2>Quick Links</h2>
+    <div class="table-contents">
+    <a href="reflections.html#pre-class-ref">#BeforeReflection&Algorithm</a>
+    <br/>
+    <a href="reflections.html#post-class-ref">#AfterReflection&Algorithm</a>
+    </div>
+
     <h2>Grading scheme</h2>
+    <hr/>
     <!-- Table with 4 columns, 10 rows -->
     <style type="text/css">
         .tg  {border-collapse:collapse;border-spacing:0;}
@@ -33,6 +40,7 @@
         .tg th{border-color:black;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
           font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
         .tg .tg-0lax{text-align:left;vertical-align:top}
+        .tg {margin-top: 20px;}
         </style>
         <table class="tg">
         <thead>
@@ -102,6 +110,7 @@
         </table>
 
     <h1>Course Schedule</h1>
+    <hr/>
     <!-- Week 10 -->
     <h2>Week 10</h2>
     <h3>Mon March 20 Statistics: Hypothesis Testing</h3>

--- a/reflections.html
+++ b/reflections.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CSC428 - Reflections</title>
+    <link href="style.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
+    <script src="https://kit.fontawesome.com/9306cde46d.js" crossorigin="anonymous"></script>
+    <script defer src="script.js"></script>
+</head>
+<body>
+
+<a href="index.html">Home</a>
+<h1>CSC428 - Reflections</h1>
+
+<div class="table-contents">
+<a href="#pre-class-ref">Pre-Class Reflection</a>
+<br/>
+<a href="#post-class-ref">Post-Class Reflection</a>
+</div>
+
+<h2 id="pre-class-ref">Pre-Class Reflection</h2>
+<hr/>
+
+<div class="template-container">
+
+<h3>#BeforeReflectionAndAlgorithm (Sun 6 pm, Mon 10 am) Template</h3>
+    <button onclick="copyToClipboard(this, 'pre-class-template')">Copy <i class="fa-solid fa-copy"></i></button>
+    <div id="pre-class-template">
+<ul>
+    <li><strong>1. #ShareableMessage (1-3 messages/points):&nbsp;</strong></li>
+</ul>
+<ul>
+    <li><strong>#InsightfulComponent</strong>: What are 1-3 insightful components from the readings? Can you express this as a message to share with someone else? For example, a linkedin, twitter, instagram post?</li>
+    <li>What <strong>#ScreenshotOrCopyPaste</strong> can you include from the reading?Why was this really cool and exciting to learn?</li>
+    <li><strong>#NextStep</strong>: What is a #NextStep based on what you learned? If you'd never learned it, you'd have done A. But since you did, what might be B? For example, can you try to apply it to your everyday life? Can you talk about it with someone? What is a question you might ask next time you're in a specific situation, what is a question it might lead you to ask, an Reflect on how what you experienced The goal is #HowCouldMakeADifference- how could what you learned lead to you doing something differently, or at least help you see how you might have taken a different action in the past (if you'd known this), or in the future (moving forward).</li>
+</ul>
+<p style="text-align: center;">[PUT ANSWER HERE]</p>
+<ul>
+    <li><strong>2. #AlgorithmForSuccess: </strong>What are your concrete contributions to succeed in the course this week? Reflect on course goals and grading schema and plan 2-3 concrete actions in IF &hellip; THEN &hellip; format, outlining how are you going to move towards these goals:</li>
+    <ul>
+        <li><strong>#CommentOrDiscussion:</strong> What is a comment/question you'd raise for discussion in Discord #AndOr BreakoutRooms? What is a #PrototypeAnswer? [#BadButUseful!]</li>
+        <li><strong>#SocialConnection</strong>: How will you engage with someone this week?</li>
+        <ul>
+            <li>In the class, what will you do or say in Discord/BreakoutRoom?</li>
+            <li>Outside the class, what message will you send to a specific person or a group to set a time to #Cowork on readings, and/or to have an #AccountabilityBuddy to check in if you worked on it at the time you were planning to?&nbsp;</li>
+        </ul>
+        <li><strong>#ContributionToClass</strong>: What can you do this week to better contribute to the class? What about next week?</li>
+        <li><strong>#CheckSignUp</strong>: #ClassDesigner/#BreakoutRoomDesigner: Checked if you have signed up for the right number of coming weeks. Have you taken some steps to start preparing? [Paste below what your plan is!] <a href="http://tiny.cc/hcschedule" target="_blank" rel="noopener">tiny.cc/hcschedule</a></li>
+        <li>#<strong>InsertYourOwnAction</strong>: What action could be helpful for you?</li>
+    </ul>
+</ul>
+<p style="text-align: center;">[PUT ANSWER HERE]</p>
+<ul>
+    <li><strong>3. #YourChoice:</strong> What else might you like to share that will help you learn or was exciting to you? E.g. something that doesn't seem related to the class reading, but was useful and came up because of your interactions in the class with people? For example, an idea inspired by what was said, or something you went and googled? (e.g. using ChatGPT)</li>
+</ul>
+<p style="text-align: center;">[PUT ANSWER HERE]</p>
+<ul>
+    <li><strong>4. #EstimateYourGrade:</strong> We want you to think about what you learned and learn to evaluate your own learning. This also allows you to more directly learn what is expected, and we will look at what you write. Our goal is for you to worry less about 'what is the right answer, will I get a bad grade', and more "what am I learning". Because of this, we ask you to provide us with an estimation of the quality of your submission from +5 to -5:&nbsp;</li>
+</ul>
+<p>-5 (strongly disagree), -3 (disagree), -1 (slightly disagree)</p>
+<p>&nbsp;0 (neither agree nor disagree)</p>
+<p>+1 (slightly agree), +3 (agree), +5 (strongly agree)</p>
+<ul>
+    <li>"What I wrote shows how I learned a great deal from this reflection"&nbsp; [ &nbsp; ]</li>
+    <li>"My reflections would make sense and be informative in teaching someone else" [&nbsp; ]</li>
+    <li>"I provided evidence that I followed an #Algorithm that helped me prepare" [&nbsp; ]</li>
+    <li>"I have a plan I am likely to follow for connecting with people contributing to class" [&nbsp; ]</li>
+</ul>
+    </div>
+
+</div>
+
+<h2 id="post-class-ref">Post-Class Reflection</h2>
+<hr/>
+
+<div class="template-container">
+    <h3>#AfterReflectionAlgorithm (Tue 6pm, Wed 10 am) Template</h3>
+    <button onclick="copyToClipboard(this, 'post-class-template')">Copy <i class="fa-solid fa-copy"></i></button>
+    <div id="post-class-template">
+    <ul>
+        <li><strong>1. #ShareableMessage (1-3 messages/points):&nbsp;</strong></li>
+    </ul>
+    <ul>
+        <li><strong>#InsightfulComponent</strong>: What are 1-3 insightful components from the class that someone said. How did my thinking change after class?</li>
+        <li><strong>#ContentToShare</strong>: What are 1-3 facts, ideas or concepts you learned from the class and why they might be useful?</li>
+    </ul>
+    <p style="text-align: center;">[PUT ANSWER HERE]</p>
+    <ul>
+        <li><strong>2. #Accountability:</strong></li>
+        <ul>
+            <li>What message did I send or action I did during class? Screenshot 1-3 things that you put into Discord, onto Figjam, or what you said.</li>
+            <li>How did I connect with someone in a class in a way that was #MutuallyBeneficial? E.g. share information, understand them better, ask for advice?</li>
+            <li>How many minutes were my video on?&nbsp;</li>
+            <li>How else did I contribute to the course and my learning?</li>
+            <li>How did your plan from last week go? What worked well, what didn't? What are you going to try differently this week? Who are you going to ask for help? More advice at: <a href="https://docs.google.com/document/d/11Z9RFJCrTzhDhzxSKWYpafpG_PKJJRGimARdkZNz3wk/edit#heading=h.7jyc6yt1q39z" target="_blank" rel="noopener">#Planning</a></li>
+        </ul>
+    </ul>
+    <p style="text-align: center;">[PUT ANSWER HERE]</p>
+    <ul>
+        <li><strong>3. #AlgorithmForSuccess: </strong>What are your concrete contributions to succeed in the course next week? Reflect on course goals and grading schema and plan 2-3 concrete actions in IF &hellip; THEN &hellip; format, outlining how are you going to move towards these goals:</li>
+        <ul>
+            <li><strong>#CouldMakeADifference</strong>: What did you learn from the classroom readings or other sources which will lead to you doing something differently, or at least help you see how you might take a different action (in the past, or the future)?</li>
+            <li><strong>#MetaSkillsPractice</strong>: What is an example of MetaSkill I want to practice (<a href="http://tiny.cc/hcmetaskills" target="_blank" rel="noopener">tiny.cc/hcmetaskills</a>)? What are 3 ways to do that in and out of the class this week?</li>
+            <li><strong>#Planning: </strong>What will you do, when, and who might you work with?&nbsp; What are concrete steps you are going to take to complete next week&rsquo;s readings and how will you participate in the lecture?&nbsp;</li>
+            <li>#<strong>InsertYourOwnAction</strong>: What action could be helpful for you?</li>
+        </ul>
+    </ul>
+    <p style="text-align: center;">[PUT ANSWER HERE]</p>
+    <ul>
+        <li><strong>4. #YourChoice:</strong> What else might you like to share that will help you learn or was exciting to you? E.g. something that doesn't seem related to the class reading, but was useful and came up because of your interactions in the class with people? For example, an idea inspired by what was said, or something you went and googled? (e.g. using ChatGPT)</li>
+    </ul>
+    <p style="text-align: center;">[PUT ANSWER HERE]</p>
+    <ul>
+        <li><strong>5. #EstimateYourGrade:</strong> We want you to think about what you learned and learn to evaluate your own learning. This also allows you to more directly learn what is expected, and we will look at what you write. Our goal is for you to worry less about 'what is the right answer, will I get a bad grade', and more "what am I learning". Because of this, we ask you to provide us with an estimation of the quality of your submission from +5 to -5:&nbsp;</li>
+    </ul>
+    <p>-5 (strongly disagree), -3 (disagree), -1 (slightly disagree)</p>
+    <p>&nbsp;0 (neither agree nor disagree)</p>
+    <p>+1 (slightly agree), +3 (agree), +5 (strongly agree)</p>
+    <ul>
+        <li>"What I wrote shows how I learned a great deal from this reflection"&nbsp; [ &nbsp; ]</li>
+        <li>"My reflections would make sense and be informative in teaching someone else" [&nbsp; ]</li>
+        <li>"I provided evidence that I followed an #Algorithm that helped me prepare" [&nbsp; ]</li>
+        <li>"I have a plan I am likely to follow for connecting with people contributing to class" [&nbsp; ]</li>
+    </ul>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,21 @@
+async function copyToClipboard(element, id) {
+    const template = document.getElementById(id || 'pre-class-template')
+
+    const clipboardItem = new ClipboardItem({
+        "text/plain": new Blob(
+            [template.innerText],
+            { type: "text/plain" }
+        ),
+        "text/html": new Blob(
+            [template.outerHTML],
+            { type: "text/html" }
+        ),
+    });
+    await navigator.clipboard.write([clipboardItem])
+    const prevText = element.innerHTML
+    element.innerText = "Copied!"
+    setTimeout(() => {
+        element.innerHTML = prevText
+    }, 1000)
+
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,42 @@
+body {
+    font-family: 'Poppins', sans-serif;
+    padding-left: 1rem;
+}
+
+hr {
+    width: 50px;
+    margin-inline: 0;
+    border: none;
+    height: 4px;
+    background: darkblue;
+}
+
+.template-container {
+    width: 80%;
+    font-size: 14px;
+}
+
+.table-contents {
+    padding: 10px;
+    background: #dcebf0;
+    width: fit-content;
+    border-radius: 5px;
+}
+
+button {
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    column-gap: 7px;
+    padding-inline: 15px;
+    padding-block: 5px;
+    outline: none;
+    border: solid 2px #aacfdb;
+    background: #dcebf0;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #aacfdb;
+}


### PR DESCRIPTION
On the home page, I added quick links that take you to the right place in the `reflections.html` page.

In the page you can see:
- Pre-class Reflection template
- Post-class Reflection template
And there's a copy button to easily copy each template.

Other fixes:
- Added a font for all text (Poppins)
- Added a small horizontal line under the H1 titles for styling